### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -430,7 +430,7 @@ nginx_start()
 {
   # Create a nginx container hosting software download locally
 
-  local IMAGE_NAME=nginx
+  local IMAGE_NAME=docker.io/library/nginx
 
   if [ -n "$NGINX_IMAGE_NAME" ]; then
     check_build_nginx_image


### PR DESCRIPTION
Changed IMAGE_NAME for nginx to docker.io/library/nginx. Just nginx will give a question on podman from which repository you want to grab the image. If you choose the top one (registry.redhat) you will get an error and the build process will fail. Setting it to docker.io/library/nginx works on both podman and docker and prevents the error