### PR TITLE
Install clang-tidy when installing the C-API

### DIFF
--- a/dockerfiles/install_dir_domino/install_domino.sh
+++ b/dockerfiles/install_dir_domino/install_domino.sh
@@ -608,6 +608,9 @@ install_capi()
   header "Install gcc and gcc++ compilers"
   install_packages gcc g++ gcc-c++ make binutils
 
+  header "Install C/C++ linter"
+  install_packages clang-tools-extra
+
   # Install OpenSSL developement required packages
   install_package openssl
 


### PR DESCRIPTION
Added a statement to also install "[clang-tidy](https://clang.llvm.org/extra/clang-tidy/)" when installing the C-API so the image can not only be used to compile but also to lint the source code.